### PR TITLE
feat(dns): switch to fullDomainName and fix Cloudflare record

### DIFF
--- a/infra/apps/cloud-primary/src/createChannelFunction.ts
+++ b/infra/apps/cloud-primary/src/createChannelFunction.ts
@@ -42,7 +42,7 @@ export async function createChannelFunction(
         zipsContainer,
         publicFunctionStoragePrefix,
         publishResult.releaseDir);
-    apiStatusCheck(publicFunctionPrefix, `Channel - ${channelName}`, channelFunc.dnsCname.hostname, ConfChannelApiCheckInterval);
+    apiStatusCheck(publicFunctionPrefix, `Channel - ${channelName}`, channelFunc.fullDomainName, ConfChannelApiCheckInterval);
 
     return {
         nameLower: channelNameLower,

--- a/infra/apps/cloud-primary/src/index.ts
+++ b/infra/apps/cloud-primary/src/index.ts
@@ -101,7 +101,7 @@ const up = async () => {
                 funcStorage.zipsContainer,
                 api.prefix,
                 apiFuncPublish.releaseDir);
-            apiStatusCheck(api.prefix, [api.name, 'API'].filter(i => i.length).join(' '), apiFunc.dnsCname.hostname, ConfCloudApiCheckInterval);
+            apiStatusCheck(api.prefix, [api.name, 'API'].filter(i => i.length).join(' '), apiFunc.fullDomainName, ConfCloudApiCheckInterval);
             publicFuncs.push({
                 name: api.name,
                 shortName: api.prefix,
@@ -333,8 +333,8 @@ const up = async () => {
         return {
             signalrUrl: signalr.signalr.hostName,
             internalFunctionUrls: internalFuncs.map(f => f.webApp.hostNames[0]),
-            publicUrls: publicFuncs.map(c => c.dnsCname.hostname),
-            channelsUrls: channelsFunctions.map(c => c.dnsCname.hostname),
+            publicUrls: publicFuncs.map(c => c.fullDomainName),
+            channelsUrls: channelsFunctions.map(c => c.fullDomainName),
             appUrls: [
                 appRb.app.url,
             ],

--- a/infra/packages/pulumi/src/cloudflare/dnsRecord.ts
+++ b/infra/packages/pulumi/src/cloudflare/dnsRecord.ts
@@ -1,15 +1,16 @@
 import { Config, Input } from '@pulumi/pulumi';
-import { Record } from '@pulumi/cloudflare';
+import { DnsRecord } from '@pulumi/cloudflare';
 
 export function dnsRecord(name: string, dnsName: Input<string>, value: Input<string>, type: 'CNAME' | 'TXT' | 'MX' | 'A', protect: boolean) {
     const config = new Config();
     const zoneId = config.requireSecret('zoneid');
-    return new Record(name, {
+    return new DnsRecord(name, {
         name: dnsName,
         zoneId,
         type,
         content: value,
         priority: type === 'MX' ? 10 : undefined,
+        ttl: 1
     }, {
         protect,
     });


### PR DESCRIPTION
Update DNS handling to use fullDomainName instead of dnsCname.hostname
for API, channel and public/channel lists. This ensures the app references
the actual deployed domain property (fullDomainName) rather than the
legacy dnsCname.hostname field, avoiding incorrect host lookups and
improving reliability of status checks and URL lists.

Also update Cloudflare DNS resource usage: use DnsRecord type from the
Pulumi Cloudflare provider, set ttl to 1, and keep zoneId as a secret.
This aligns with the provider types and explicitly sets TTL for records.

These changes correct domain resolution, harmonize DNS record creation,
and prevent runtime mismatches when building lists of public and channel
URLs.