### PR TITLE
fix(ci): remove pnpm filter when installing deps

### DIFF
--- a/.github/workflows/infra-deploy_reusable.yml
+++ b/.github/workflows/infra-deploy_reusable.yml
@@ -72,7 +72,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: 📦️ Installing dependencies
-        run: pnpm i --frozen-lockfile --filter=${{ inputs.project }}
+        run: pnpm i --frozen-lockfile
 
       - name: 🔎 Determine stack
         shell: bash


### PR DESCRIPTION
Remove the --filter option from the pnpm install step in the
infra-deploy_reusable workflow. The install now runs with
--frozen-lockfile only, ensuring the lockfile is respected and
dependencies are installed consistently across runners.

This prevents failures or incomplete installs when filtering by a
project input that does not accurately reflect workspace package
boundaries, and simplifies the workflow behavior.