### PR TITLE
fix(faq): rich descriptions and bump package versionHandle non-string FAQ in Faq1 by conditionally rendering:

### DIFF
--- a/web/packages/cms-components-marketing/package.json
+++ b/web/packages/cms-components-marketing/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@signalco/cms-components-marketing",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "license": "MIT",
     "type": "module",
     "sideEffects": false,

--- a/web/packages/cms-components-marketing/src/Faq/Faq1.tsx
+++ b/web/packages/cms-components-marketing/src/Faq/Faq1.tsx
@@ -25,9 +25,7 @@ export function Faq1({ tagline, header, description, features, ctas }: SectionDa
                                 {typeof feature.description === 'string' ? (
                                     <Typography level="body1">{feature.description}</Typography>
                                 ) : (
-                                    <>
-                                        {feature.description ?? null}
-                                    </>
+                                    feature.description
                                 )}
                             </Accordion>
                         </Fragment>

--- a/web/packages/cms-components-marketing/src/Faq/Faq1.tsx
+++ b/web/packages/cms-components-marketing/src/Faq/Faq1.tsx
@@ -22,7 +22,13 @@ export function Faq1({ tagline, header, description, features, ctas }: SectionDa
                             {featureIndex > 0 && <Divider />}
                             <Accordion defaultOpen variant="plain">
                                 <Typography semiBold>{feature.header}</Typography>
-                                <p>{feature.description}</p>
+                                {typeof feature.description === 'string' ? (
+                                    <Typography level='body1'>{feature.description}</Typography>
+                                ) : (
+                                    <>
+                                        {feature.description ?? null}
+                                    </>
+                                )}
                             </Accordion>
                         </Fragment>
                     ))}

--- a/web/packages/cms-components-marketing/src/Faq/Faq1.tsx
+++ b/web/packages/cms-components-marketing/src/Faq/Faq1.tsx
@@ -23,7 +23,7 @@ export function Faq1({ tagline, header, description, features, ctas }: SectionDa
                             <Accordion defaultOpen variant="plain">
                                 <Typography semiBold>{feature.header}</Typography>
                                 {typeof feature.description === 'string' ? (
-                                    <Typography level='body1'>{feature.description}</Typography>
+                                    <Typography level="body1">{feature.description}</Typography>
                                 ) : (
                                     <>
                                         {feature.description ?? null}


### PR DESCRIPTION
Typography for string descriptions and render JSX/ nodesdirectly for non-string values. string-wrapping JSX andensures rich content (elements fragments) displays correctly.

Bumpsignalco/cms-componentseting0.1. to0.1.2 to reflect thecomponent behavior fix.